### PR TITLE
Casmcloud 1204 Pin markupsafe version < 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.5] - 2022-02-25
+### Fixed
+- Fix markupsafe missing function failure (pin markupsafe < 2.1.0)
+
+
 ## [1.3.4] - 2021-10-25 
 ### Changed
 - upgrade Yamale package from 3.0.8 -> 4.0.0

--- a/manifestgen/__init__.py
+++ b/manifestgen/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020-2022] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,4 +21,4 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 # pylint: skip-file
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.20.0
 jinja2==2.11.3
 pyyaml==5.4.1
 certifi==2017.4.17
+markupsafe<2.1.0


### PR DESCRIPTION
## Summary and Scope

In version 2.1.0 of markupsafe, a function was removed that many third-party packages rely on.  This causes widespread build and runtime failures, including in manifestgen.  The workaround, until third-party packages adapt to this change, is to pin markupsafe at less than 2.1.0.


This change is backward compatible.

## Issues and Related PRs

* Resolves [CASMCLOUD-1204](https://jira-pro.its.hpecorp.net:8443/browse/CASMCLOUD-1204)

## Testing

This was simply tested by verifying a successful build.  The change causes manifestgen to pull in the same version of markupsafe it has always pulled in (instead of moving forward to a newer broken version).

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

