### PR TITLE
Remove redundant metadata in feature RPM names

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -16,7 +16,6 @@ pipeline {
     }
 
     environment {
-        BUILD_METADATA = getRpmRevision(isStable: isStable)
         GIT_REPO_NAME = getRepoName()
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
     }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ NAME ?= ${GIT_REPO_NAME}
 ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags | tr -s '-' '~' | tr -d '^v')
 endif
-BUILD_METADATA ?= "1~development~$(shell git rev-parse --short HEAD)"
 RPM_SPEC_FILE ?= ${NAME}.spec
 RPM_SOURCE_NAME ?= ${NAME}-${VERSION}
 RPM_BUILD_DIR ?= $(PWD)/dist/rpmbuild
@@ -22,7 +21,7 @@ rpm_package_source:
 	tar --transform 'flags=r;s,^,/$(RPM_SOURCE_NAME)/,' --exclude .git --exclude dist -cvjf $(RPM_SOURCE_PATH) .
 
 rpm_build_source:
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ts $(RPM_SOURCE_PATH) --define "_topdir $(RPM_BUILD_DIR)"
+	rpmbuild -ts $(RPM_SOURCE_PATH) --define "_topdir $(RPM_BUILD_DIR)"
 
 rpm_build:
-	BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ba $(RPM_SPEC_FILE) --define "_topdir $(RPM_BUILD_DIR)"
+	rpmbuild -ba $(RPM_SPEC_FILE) --define "_topdir $(RPM_BUILD_DIR)"

--- a/manifestgen.spec
+++ b/manifestgen.spec
@@ -4,7 +4,7 @@ Name: manifestgen
 License: MIT License
 Summary: Cray Command Line Tool
 Version: %(echo ${VERSION})
-Release: %(echo ${BUILD_METADATA})
+Release: 1
 Vendor: Cray Inc.
 Group: Cloud
 Source: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Feature RPM names have redundant information from #10 and #9 , this fixes that.

Currently: https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/manifestgen/x86_64/manifestgen-v1.3.5_1_gc71d3a9-1~development~c71d3a9.x86_64.rpm

After: https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/manifestgen/x86_64/manifestgen-1.3.6~1~g07ab6f6-1.x86_64.rpm