### PR TITLE
Without .version main shouldn't build stable

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
 
 def pythonVersion = '3.6.15'
 def promotionToken = ~"(release\\/.*)"
-def isStable = env.TAG_NAME != null || env.BRANCH_NAME ==~ promotionToken ? true : false
+def isStable = env.TAG_NAME != null ? true : false
 pipeline {
     agent {
         label "metal-gcp-builder"


### PR DESCRIPTION
This is leftover from #9, #10, and #11.

Stable builds are really on git-tags, and the branch value in this statement is `main` not `master`. This really just removes the incorrect regex.