### PR TITLE
Fix permissions on buildenv

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -63,7 +63,7 @@ pipeline {
         stage('Build: RPM') {
             agent {
                 docker {
-                    args "-u root"
+                    args "-u root -v ${env.WORKSPACE}:/workspace"
                     label "metal-gcp-builder"
                     reuseNode true
                     image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python:${pythonVersion}"
@@ -71,6 +71,7 @@ pipeline {
             }
             steps {
                 sh "make rpm"
+                sh "chown -R jenkins:jenkins /workspace"
             }
         }
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: #13 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Stable builds are failing to write logs due to a permission mismatch on the buildenv. This resolves that by `chown`ing the buildenv before publishing.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
