### PR TITLE
Tidy jenkins lint fixes

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,18 +1,25 @@
 name: Snyk
+
 on: push
+
 jobs:
   security:
+    name: Security Scanning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
-      #  continue-on-error: true # To make sure that SARIF upload gets called
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Also fetch git-tags
+      - name: Setup Snyk
+        uses: snyk/actions/setup@master
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.6'
+      - name: Snyk monitor
+        run: |
+          pip install -U wheel
+          pip install .
+          snyk test --file=setup.py --command=python3
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      #  with:
-      #    args: --sarif-file-output=snyk.sarif
-      #- name: Upload result to GitHub Code Scanning
-      #  uses: github/codeql-action/upload-sarif@v1
-      #  with:
-      #    sarif_file: snyk.sarif

--- a/manifestgen/generate.py
+++ b/manifestgen/generate.py
@@ -25,10 +25,11 @@
 
 import argparse
 import os
-import pkg_resources
 import sys
 import traceback
 import warnings
+
+import pkg_resources
 
 from manifestgen import ioutils
 from manifestgen.customizations import Customizations

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ from os.path import join
 from os import devnull
 import re
 
+import pkg_resources
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -76,12 +78,15 @@ def get_version():
 
         if dirty != "":
             version += ".dev1"
-
     else:
-        # Extract the version from the PKG-INFO file.
-        with open(join(d, "PKG-INFO")) as f:
-            version = version_re.search(f.read()).group(1)
-
+        try:
+            # Extract the version from the PKG-INFO file.
+            with open(join(d, "PKG-INFO")) as f:
+                version = version_re.search(f.read()).group(1)
+        except FileNotFoundError:
+            # Maybe this package is already installed, and setup.py is invoked
+            # out of context by a scanner.
+            version = pkg_resources.get_distribution("manifestgen").version
     return version
 
 setup(


### PR DESCRIPTION
Fixes workflows following the merge of #15. #15 had to merge before these could be fixed because the workflows run from the default branch (in this case, master).