### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.6'
+          python-version: '3.10'
       - name: Snyk monitor
         run: |
           pip install -U wheel

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.6'
+        python-version: '3.10'
     - name: nox
       env:
         GIT_REPO_NAME: "${GITHUB_REPOSITORY#*/}"

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,7 +27,7 @@
 
 def pythonImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle-python'
 def isStable = env.TAG_NAME != null ? true : false
-def pythonVersion = '3.6.15'
+def pythonVersion = '3.10'
 pipeline {
     agent {
         label "metal-gcp-builder"

--- a/manifestgen.spec
+++ b/manifestgen.spec
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-%global __python /usr/local/bin/python3.6
+%global __python /usr/local/bin/python3.10
 %define __pyinstaller /home/jenkins/.local/bin/pyinstaller
 %define install_dir /opt/cray/loftsman
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Several dependencies are unable to update due to using an older version of Python (e.g. Jinja). This upgrades `manifestgen` to Python 3.10.

This should unblock all or some of the pending dependency update PRs.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)

I installed it onto Redbull's PIT and verified it could generate a manifest:

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen --version
manifestgen 1.3.7.post3
```

```bash
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen -c site-init/customizations.yaml -i /tmp/platform.yaml -o manifest.yaml
```

The generated `manifest.yaml` had all the expected items contained.

### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
