### PR TITLE
Revert "Bump yamale from 4.0.0 to 4.0.4"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
         }
     },
     install_requires=[
-        'yamale==4.0.4',
+        'yamale==4.0.0',
         'semver==2.13.0',
         'requests>=2.20.0',
         'jinja2==3.1.2',


### PR DESCRIPTION
Reverts Cray-HPE/manifestgen#16

This ended up failing with a stacktrace:

```bash
redbull-ncn-m001-pit:~ # manifestgen --version
Traceback (most recent call last):
  File "generate.py", line 35, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "customizations.py", line 31, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "schema.py", line 25, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "validator.py", line 28, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "yamale/__init__.py", line 4, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 499, in exec_module
  File "yamale/version.py", line 6, in <module>
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEI6KuYm5/yamale/VERSION'
[60834] Failed to execute script 'generate' due to unhandled exception!
```

Rolling this PR back produced a working `manifestgen`:

```bash
redbull-ncn-m001-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/manifestgen/x86_64/manifestgen-1.3.7~7~gc81563e-1.x86_64.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/manifestgen/x86_64/manifestgen-1.3.7~7~gc81563e-1.x86_64.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:manifestgen-1.3.7~7~gc81563e-1   ################################# [100%]
redbull-ncn-m001-pit:~ # manifestgen --version
manifestgen 1.3.7.post7
redbull-ncn-m001-pit:/var/www/ephemeral/prep # rm manifest.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # manifestgen -c site-init/customizations.yaml -i /tmp/platform.yaml -o manifest.yaml
echo $?redbull-ncn-m001-pit:/var/www/ephemeral/prep # echo $?
0
redbull-ncn-m001-pit:/var/www/ephemeral/prep # ls -ls manifest.yaml
44 -rw-r--r-- 1 root root 43108 Nov 16 17:28 manifest.yaml
redbull-ncn-m001-pit:/var/www/ephemeral/prep # head !$
head manifest.yaml
apiVersion: manifests/v1beta1
metadata:
  name: platform
spec:
  charts:
  - name: cray-metrics-server
    namespace: kube-system
    source: csm-algol60
    version: 0.4.0
  - name: cray-drydock
```